### PR TITLE
add streaming support

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -650,22 +650,24 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	raw := false
-	for k,v := range result.Headers {
-		if strings.ToLower(k) == "content-type" {
-			for _, x := range v {
-				if strings.HasPrefix(x, "text/") {
-					raw = true
-				}
-			}
+	var body io.Reader
+
+	switch v := result.Body.(type) {
+	case io.Reader:
+		body = v
+	case string:
+		body = strings.NewReader(v)
+	case []byte:
+		body = bytes.NewReader(v)
+	default:
+		jsonBytes, err := json.Marshal(result.Body)
+		if err != nil {
+			c.errorHandler(w, r, err, &result)
+			return
 		}
+		body = bytes.NewReader(jsonBytes)
 	}
 
-	// If no error, encode the body and the result code
-	if raw {
-		_ = EncodeRawResponse(result.Body, &result.Code, {{#addResponseHeaders}} result.Headers,{{/addResponseHeaders}} w)
-	} else {
-		_ = EncodeJSONResponse(result.Body, &result.Code, {{#addResponseHeaders}} result.Headers,{{/addResponseHeaders}} w)
-	}
+	_ = EncodeRawResponse(body, &result.Code, {{#addResponseHeaders}} result.Headers,{{/addResponseHeaders}} w)
 
 }{{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"bytes"
 )
 
 // A Route defines the parameters for an api endpoint
@@ -132,14 +133,16 @@ func EncodeJSONResponse(i interface{}, status *int,{{#addResponseHeaders}} heade
 
 // EncodeRawResponse sends raw bytes to the http.ResponseWriter
 func EncodeRawResponse(i interface{}, status *int,{{#addResponseHeaders}} headers map[string][]string,{{/addResponseHeaders}} w http.ResponseWriter) error {
-	var body []byte
+	var body io.Reader
 	switch v := i.(type) {
-		case string:
-			body = []byte(v)
-		case []byte:
-			body = v
-		default:
-			return fmt.Errorf("invalid data type: %T", i)
+	case io.Reader:
+		body = v
+	case string:
+		body = strings.NewReader(v)
+	case []byte:
+		body = bytes.NewReader(v)
+	default:
+		return fmt.Errorf("invalid data type: %T", i)
 	}
 
 	wHeader := w.Header()
@@ -157,7 +160,7 @@ func EncodeRawResponse(i interface{}, status *int,{{#addResponseHeaders}} header
 		w.WriteHeader(http.StatusOK)
 	}
 
-	_, err := w.Write(body)
+	_, err := io.Copy(w, body)
 	return err
 }
 

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -132,19 +132,7 @@ func EncodeJSONResponse(i interface{}, status *int,{{#addResponseHeaders}} heade
 }
 
 // EncodeRawResponse sends raw bytes to the http.ResponseWriter
-func EncodeRawResponse(i interface{}, status *int,{{#addResponseHeaders}} headers map[string][]string,{{/addResponseHeaders}} w http.ResponseWriter) error {
-	var body io.Reader
-	switch v := i.(type) {
-	case io.Reader:
-		body = v
-	case string:
-		body = strings.NewReader(v)
-	case []byte:
-		body = bytes.NewReader(v)
-	default:
-		return fmt.Errorf("invalid data type: %T", i)
-	}
-
+func EncodeRawResponse(body io.Reader, status *int,{{#addResponseHeaders}} headers map[string][]string,{{/addResponseHeaders}} w http.ResponseWriter) error {
 	wHeader := w.Header()
 	{{#addResponseHeaders}}
 	for key, values := range headers {


### PR DESCRIPTION
When writing output from an endpoint, we now have a type switch.  `[]byte`, `string`, and `io.Reader` will be treated opaquely (no JSON-treatment).  Any other type will attempt to be JSON marshaled before being written.

This allows endpoints to do this:

```go
return ResponseWithHeaders(
	http.StatusOK,
	map[string][]string{
		"Content-Type": []string{"text/csv"},
	},
	strings.NewReader("this,is,the,result"),
), nil
```